### PR TITLE
fix: improve logger configuration and exception logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ All modern .Net Core applications are supported, up to .Net 9.0.
 
 ### Configuration
 
-The Honeybadger Notifier can be configured using the `HoneybadgerOptions` class
-(or `HoneybadgerLoggingOptions` when using as a logger).
+The Honeybadger Notifier can be configured using the `HoneybadgerOptions` class.
 Honeybadger can be configured by passing the options when registering the service,
 or through your `appsettings.json` file.
 
@@ -30,14 +29,14 @@ See below for examples on how to configure Honeybadger for different types of ap
 2. Register the _Honeybadger Middleware_:
    ```c#
    var builder = WebApplication.CreateBuilder(args);
-   builder.AddHoneybadger(new HoneybadgerOptions("api_key"));
+   builder.AddHoneybadger(new HoneybadgerOptions("apiKey"));
    ```
    
    Or you can configure Honeybadger through your `appsettings.json` file, by adding a `Honeybadger` section:
    ```json
    {
      "Honeybadger": {
-       "ApiKey": "api_key",
+       "ApiKey": "apiKey",
        "AppEnvironment": "Development",
        "ReportData": true 
      }
@@ -61,7 +60,7 @@ app.MapGet("/", ([FromServices] IHoneybadgerClient client) =>
 });
 ```
 
-Any unhandled exceptions should be reported to Honeybadger automatically:
+Any unhandled exceptions should be reported to Honeybadger automatically (unless `ReportUnhandledExceptions` is set to false):
 ```c#
 app.MapGet("/debug", () =>
 {
@@ -77,37 +76,41 @@ See example project in `examples/Honeybadger.DotNetCoreWebApp`.
    ```
    dotnet add package Honeybadger.Extensions.Logging
    ```
-2. Register the custom logging provider:
+2. Register Honeybadger and additionally the custom logging provider:
    ```c#
    var builder = WebApplication.CreateBuilder(args);
-   builder.Logging.AddHoneybadger(new HoneybadgerLoggingOptions 
-   {
-       ApiKey = "api_key",
-       Environment = "Development",
-       ReportData = true,
-       MinimumNoticeLevel = LogLevel.Error,
-       MinimumBreadcrumbLevel = LogLevel.Information
-   });
+   // or set the configuration in the appsettings.json file
+   builder.AddHoneybadger(new HoneybadgerOptions("apiKey"));
+   builder.Logging.AddHoneybadger();
    ```
 
-   Or you can configure Honeybadger through your `appsettings.json` file, by adding a `Honeybadger` section inside the `Logging` section:
+   You should also configure the minimum log level as you would configure other log providers in .Net Core.
+   The following would report only logged errors:
    ```json
    {
      "Logging": {
        "Honeybadger": {
-          "ApiKey": "api_key",
-          "AppEnvironment": "Development",
-          "ReportData": true,
-          "MinimumNoticeLevel": "Error",
-          "MinimumBreadcrumbLevel": "Information"
+          "Default": "Error"
        }
      }
    }
    ```
-   And simply call `AddHoneybadger` without any parameters:
+   And simply call `AddHoneybadger` and `Logging.AddHoneybadger` without any parameters:
    ```c#
     var builder = WebApplication.CreateBuilder(args);
+    builder.AddHoneybadger();
     builder.Logging.AddHoneybadger();
+   ```
+   Note: If you want to disable automatic reporting of unhandled exceptions, you can set the `ReportUnhandledExceptions` property to `false` in the `HoneybadgerOptions`:
+   ```json
+   {
+     "Honeybadger": {
+       "ApiKey": "apiKey",
+       "AppEnvironment": "Development",
+       "ReportData": true,
+       "ReportUnhandledExceptions": false
+     }
+   }
    ```
 
 #### Usage

--- a/examples/Honeybadger.DotNetCoreWebApp.Logger/Program.cs
+++ b/examples/Honeybadger.DotNetCoreWebApp.Logger/Program.cs
@@ -1,17 +1,49 @@
+using Honeybadger;
+using Honeybadger.DotNetCore;
+using Honeybadger.Extensions.Logging;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.AddHoneybadger();
 builder.Logging.AddHoneybadger();
 
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
-app.MapGet("/notify", ([FromServices] ILogger<Program> logger) =>
+app.MapGet("/", (IEnumerable<EndpointDataSource> endpointSources) =>
 {
-    logger.LogError("Hello from Honeybadger.Logger! Improved error handling with Honeybadger.");
-    
-    return "Log reported to Honeybadger. Check your dashboard!";
+    var routes = string.Join("\n", endpointSources.SelectMany(source => source.Endpoints));
+    return $"Hello World! Visit the following routes to test:\n{routes}";
 });
+
+app.MapGet("/notify", ([FromServices] ILogger<Program> logger, IHoneybadgerClient hb) =>
+{
+    var shouldReport = hb.Options.ShouldReport();
+    if (!shouldReport)
+    {
+        return "Log won't be reported to Honeybadger, " +
+               "because its api key is not set or the environment is in the list of DevelopmentEnvironments.";
+    }
+    
+    logger.LogInformation("Hello from Honeybadger.Logger!");
+    
+    return "Log should be reported to Honeybadger. Check your dashboard!";
+});
+
+app.MapGet("/throw", ([FromServices] ILogger<Program> logger, IHoneybadgerClient hb) =>
+{
+    if (!hb.Options.ShouldReport())
+    {
+        throw new Exception("This exception should not be reported to Honeybadger because of either ApiKey or AppEnvironment.");
+    }
+    
+    if (!hb.Options.ReportUnhandledExceptions)
+    {
+        throw new Exception("This exception should not be reported because ReportUnhandledExceptions is false.");    
+    }
+    
+    throw new Exception("This exception should be reported to Honeybadger.");
+});
+
 
 app.Run();
 

--- a/examples/Honeybadger.DotNetCoreWebApp.Logger/appsettings.json
+++ b/examples/Honeybadger.DotNetCoreWebApp.Logger/appsettings.json
@@ -5,10 +5,16 @@
       "Microsoft.AspNetCore": "Warning"
     },
     "Honeybadger": {
-      "ApiKey": "api_key",
-      "AppEnvironment": "development",
-      "ReportData": true
+      "LogLevel": {
+        "Default": "Error"
+      }
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Honeybadger": {
+    "ApiKey": "api_key",
+    "AppEnvironment": "Development",
+    "ReportData": true,
+    "ReportUnhandledExceptions": false
+  }
 }

--- a/examples/Honeybadger.DotNetCoreWebApp/Honeybadger.DotNetCoreWebApp.csproj
+++ b/examples/Honeybadger.DotNetCoreWebApp/Honeybadger.DotNetCoreWebApp.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Honeybadger.DotNetCore\Honeybadger.DotNetCore.csproj" />
+      <ProjectReference Include="..\..\src\Honeybadger.Extensions.Logging\Honeybadger.Extensions.Logging.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Honeybadger.DotNetCore/BuilderExtensions.cs
+++ b/src/Honeybadger.DotNetCore/BuilderExtensions.cs
@@ -15,11 +15,34 @@ public static class ServiceCollectionExtensions
     {
         //services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         
-        builder.Services.Configure<HoneybadgerOptions>(builder.Configuration.GetSection("Honeybadger"));
-
+        var configSection = builder.Configuration.GetSection("Honeybadger");
+        
         if (configure is not null)
         {
-            builder.Services.Configure(configure);    
+            var options = new HoneybadgerOptions();
+            configSection.Bind(options);            
+            configure(options);
+            builder.Services.Configure<HoneybadgerOptions>(config =>
+            {
+                config.ApiKey = options.ApiKey;
+                config.AppEnvironment = options.AppEnvironment;
+                config.BreadcrumbsEnabled = options.BreadcrumbsEnabled;
+                config.DevelopmentEnvironments = options.DevelopmentEnvironments;
+                config.Endpoint = options.Endpoint;
+                config.FilterKeys = options.FilterKeys;
+                config.HostName = options.HostName;
+                config.HttpClient = options.HttpClient;
+                config.MaxBreadcrumbs = options.MaxBreadcrumbs;
+                config.ProjectRoot = options.ProjectRoot;
+                config.ReportData = options.ReportData;
+                config.Revision = options.Revision;
+                config.ReportUnhandledExceptions = options.ReportUnhandledExceptions;
+                
+            });
+        }
+        else
+        {
+            builder.Services.Configure<HoneybadgerOptions>(configSection);
         }
         
         builder.Services

--- a/src/Honeybadger.DotNetCore/Honeybadger.DotNetCore.csproj
+++ b/src/Honeybadger.DotNetCore/Honeybadger.DotNetCore.csproj
@@ -18,13 +18,16 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Honeybadger" Version="0.4.0" />
       <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
       <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\Honeybadger\Honeybadger.csproj" />
     </ItemGroup>
     
 </Project>

--- a/src/Honeybadger.DotNetCore/HoneybadgerMiddleware.cs
+++ b/src/Honeybadger.DotNetCore/HoneybadgerMiddleware.cs
@@ -30,8 +30,12 @@ public class HoneybadgerMiddleware
         }
         catch (Exception exception)
         {
-            // we don't want to block execution, so no await here
-            _ = client.NotifyAsync(exception).ConfigureAwait(false);
+            if (client.Options.ShouldReport() &&
+                client.Options.ReportUnhandledExceptions)
+            {
+                // we don't want to block execution, so no await here
+                _ = client.NotifyAsync(exception).ConfigureAwait(false);    
+            }
             throw;
         }
     }

--- a/src/Honeybadger.DotNetCore/HoneybadgerStartupFilter.cs
+++ b/src/Honeybadger.DotNetCore/HoneybadgerStartupFilter.cs
@@ -44,8 +44,10 @@ public class HoneybadgerStartupFilter : IStartupFilter
         private static void LogException(Exception exception, HttpContext httpContext)
         {
             httpContext.Items.TryGetValue(HoneybadgerMiddleware.HttpContextItemsKey, out var clientObject);
-
-            if (clientObject is IHoneybadgerClient client)
+            
+            if (clientObject is IHoneybadgerClient client && 
+                client.Options.ShouldReport() && 
+                client.Options.ReportUnhandledExceptions)
             {
                 // no need to await, we're in a fire-and-forget context
                 client.NotifyAsync(exception).ConfigureAwait(false);

--- a/src/Honeybadger.Extensions.Logging/Honeybadger.Extensions.Logging.csproj
+++ b/src/Honeybadger.Extensions.Logging/Honeybadger.Extensions.Logging.csproj
@@ -18,11 +18,14 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Honeybadger" Version="0.4.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.1" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Honeybadger\Honeybadger.csproj" />
     </ItemGroup>
     
 </Project>

--- a/src/Honeybadger.Extensions.Logging/HoneybadgerLoggerProvider.cs
+++ b/src/Honeybadger.Extensions.Logging/HoneybadgerLoggerProvider.cs
@@ -10,9 +10,9 @@ public class HoneybadgerLoggerProvider : ILoggerProvider
 {
     private readonly IHoneybadgerClient _client;
     private readonly IDisposable _onChangeToken;
-    private HoneybadgerLoggingOptions _currentConfig;
+    private HoneybadgerLoggerOptions _currentConfig;
 
-    public HoneybadgerLoggerProvider(IHoneybadgerClient client, IOptionsMonitor<HoneybadgerLoggingOptions> config)
+    public HoneybadgerLoggerProvider(IHoneybadgerClient client, IOptionsMonitor<HoneybadgerLoggerOptions> config)
     {
         _client = client;
         _currentConfig = config.CurrentValue;
@@ -21,7 +21,6 @@ public class HoneybadgerLoggerProvider : ILoggerProvider
     
     public ILogger CreateLogger(string categoryName)
     {
-        _client.Configure(_currentConfig);
         return new HoneybadgerLogger(_client, () => _currentConfig);
     }
     

--- a/src/Honeybadger.Extensions.Logging/HoneybadgerLoggingOptions.cs
+++ b/src/Honeybadger.Extensions.Logging/HoneybadgerLoggingOptions.cs
@@ -1,16 +1,5 @@
-using Microsoft.Extensions.Logging;
-
 namespace Honeybadger.Extensions.Logging;
 
-public class HoneybadgerLoggingOptions : HoneybadgerOptions
+public class HoneybadgerLoggerOptions
 {
-    /// <summary>
-    /// Logs with this level or higher will be stored as breadcrumbs
-    /// </summary>
-    public LogLevel MinimumBreadcrumbLevel { get; set; } = LogLevel.Information;
-
-    /// <summary>
-    /// Logs with this level or higher will be reported to Honeybadger
-    /// </summary>
-    public LogLevel MinimumNoticeLevel { get; set; } = LogLevel.Error;
 }

--- a/src/Honeybadger.Extensions.Logging/LoggerFactoryExtensions.cs
+++ b/src/Honeybadger.Extensions.Logging/LoggerFactoryExtensions.cs
@@ -21,12 +21,12 @@ public static class LoggerFactoryExtensions
             ServiceDescriptor.Singleton<ILoggerProvider, HoneybadgerLoggerProvider>());
         
         LoggerProviderOptions.RegisterProviderOptions
-            <HoneybadgerLoggingOptions, HoneybadgerLoggerProvider>(builder.Services);
+            <HoneybadgerLoggerOptions, HoneybadgerLoggerProvider>(builder.Services);
 
         return builder;
     }
 
-    public static ILoggingBuilder AddHoneybadger(this ILoggingBuilder builder, Action<HoneybadgerLoggingOptions> configure)
+    public static ILoggingBuilder AddHoneybadger(this ILoggingBuilder builder, Action<HoneybadgerLoggerOptions> configure)
     {
         builder.AddHoneybadger();
         builder.Services.Configure(configure);

--- a/src/Honeybadger/HoneybadgerClient.cs
+++ b/src/Honeybadger/HoneybadgerClient.cs
@@ -168,6 +168,11 @@ public class HoneybadgerClient : IHoneybadgerClient, IDisposable
 
     private async Task Send(Notice notice)
     {
+        if (!Options.ShouldReport())
+        {
+            return;
+        }
+        
         // Console.WriteLine("Ready to send report to Honeybadger");
         var request = new HttpRequestMessage(HttpMethod.Post, "v1/notices");
         var json = JsonSerializer.Serialize(notice, new JsonSerializerOptions
@@ -190,7 +195,7 @@ public class HoneybadgerClient : IHoneybadgerClient, IDisposable
         }
         catch (Exception ex)
         {
-            await Console.Error.WriteLineAsync(ex.Message);
+            // await Console.Error.WriteLineAsync(ex.Message);
         }
     }
 

--- a/src/Honeybadger/HoneybadgerOptions.cs
+++ b/src/Honeybadger/HoneybadgerOptions.cs
@@ -5,22 +5,22 @@ public class HoneybadgerOptions
     /// <summary>
     /// Required. The project's private API key.
     /// </summary>
-    public string ApiKey { get; set; }
+    public string ApiKey { get; set; } = null!;
 
     /// <summary>
     /// The path to the project's executable code.
     /// </summary>
-    public string? ProjectRoot { get; set; } = null;
+    public string? ProjectRoot { get; set; }
 
     /// <summary>
     /// The environment name of the application.
     /// </summary>
-    public string? AppEnvironment { get; set; } = null;
+    public string? AppEnvironment { get; set; } = "Production";
 
     /// <summary>
     /// The hostname of the system.
     /// </summary>
-    public string HostName { get; set; }
+    public string HostName { get; set; } = "";
 
     /// <summary>
     /// The base API Endpoint
@@ -46,7 +46,7 @@ public class HoneybadgerOptions
     /// <summary>
     /// The revision of the current deploy
     /// </summary>
-    public string? Revision { get; set; }
+    public string? Revision { get; set; } = null;
 
     /// <summary>
     /// Allow/disallow breadcrumbs.
@@ -62,53 +62,14 @@ public class HoneybadgerOptions
     /// Mostly here to be utilized by unit tests.
     /// </summary>
     public HttpClient? HttpClient { get; set; }
-
-    public HoneybadgerOptions()
-    {
-        ApiKey = Environment.GetEnvironmentVariable("HONEYBADGER_API_KEY") ?? "";
-        ProjectRoot = Environment.GetEnvironmentVariable("HONEYBADGER_PROJECT_ROOT");
-        AppEnvironment = (Environment.GetEnvironmentVariable("HONEYBADGER_APP_ENVIRONMENT") ??
-                          Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "development").ToLower();
-        HostName = Environment.GetEnvironmentVariable("HONEYBADGER_HOSTNAME") ?? Constants.DefaultHostname;
-        var endpoint = Environment.GetEnvironmentVariable("HONEYBADGER_ENDPOINT");
-        if (endpoint != null)
-        {
-            Endpoint = new Uri(endpoint);
-        }
-
-        var filterKeys = GetArrayFromEnv("HONEYBADGER_FILTER_KEYS");
-        if (filterKeys != null)
-        {
-            FilterKeys = filterKeys;
-        }
-
-        var devEnvironments = GetArrayFromEnv("HONEYBADGER_DEVELOPMENT_ENVIRONMENTS");
-        if (devEnvironments != null)
-        {
-            DevelopmentEnvironments = devEnvironments;
-        }
-
-        ReportData = GetBoolFromEnv("HONEYBADGER_REPORT_DATA") ?? false;
-        Revision = Environment.GetEnvironmentVariable("HONEYBADGER_REVISION");
-
-        var breadcrumbsEnabled = GetBoolFromEnv("HONEYBADGER_BREADCRUMBS_ENABLED");
-        if (breadcrumbsEnabled.HasValue)
-        {
-            BreadcrumbsEnabled = breadcrumbsEnabled.Value;
-        }
-
-        var maxBreadcrumbs = GetIntFromEnv("HONEYBADGER_MAX_BREADCRUMBS");
-        if (maxBreadcrumbs.HasValue)
-        {
-            MaxBreadcrumbs = maxBreadcrumbs.Value;
-        }
-    }
-
-    public HoneybadgerOptions(string apiKey) : this()
-    {
-        ApiKey = apiKey;
-    }
-
+    
+    /// <summary>
+    /// Automatically report unhandled exceptions for
+    /// .Net Core web applications by registering a middleware
+    /// to catch unhandled exceptions.
+    /// </summary>
+    public bool ReportUnhandledExceptions { get; set; } = true; 
+    
     public bool ShouldReport()
     {
         if (string.IsNullOrEmpty(ApiKey))
@@ -122,37 +83,5 @@ public class HoneybadgerOptions
         }
         
         return !DevelopmentEnvironments.Contains(AppEnvironment, StringComparer.InvariantCultureIgnoreCase);
-    }
-
-    private static string[]? GetArrayFromEnv(string envName)
-    {
-        var result = Environment.GetEnvironmentVariable(envName);
-        return result?.Split(',').Select(i => i.Trim()).ToArray();
-    }
-
-    private static bool? GetBoolFromEnv(string envName)
-    {
-        var readFromEnv = false;
-        var envValue = false;
-        var envValueStr = Environment.GetEnvironmentVariable(envName);
-        if (envValueStr != null)
-        {
-            readFromEnv = bool.TryParse(envValueStr, out envValue);
-        }
-
-        return readFromEnv ? envValue : null;
-    }
-
-    private static int? GetIntFromEnv(string envName)
-    {
-        var readFromEnv = false;
-        var envValue = 0;
-        var envValueStr = Environment.GetEnvironmentVariable(envName);
-        if (envValueStr != null)
-        {
-            readFromEnv = int.TryParse(envValueStr, out envValue);
-        }
-
-        return readFromEnv ? envValue : null;
     }
 }

--- a/tests/Honeybadger.Tests/HoneybadgerClientTest.cs
+++ b/tests/Honeybadger.Tests/HoneybadgerClientTest.cs
@@ -17,8 +17,9 @@ public class HoneybadgerClientTest
     [Fact]
     public void InitializesClient()
     {
-        var options = Options.Create(new HoneybadgerOptions("test")
+        var options = Options.Create(new HoneybadgerOptions
         {
+            ApiKey = "test",
             ReportData = false
         });
         
@@ -60,8 +61,9 @@ public class HoneybadgerClientTest
                 Content = new StringContent("")
             });
         
-        var options = Options.Create(new HoneybadgerOptions("test")
+        var options = Options.Create(new HoneybadgerOptions
         {
+            ApiKey = "test",
             HttpClient = new HttpClient(mockHttpHandler.Object)
         });
         var client = new HoneybadgerClient(options);
@@ -94,8 +96,9 @@ public class HoneybadgerClientTest
                 Content = new StringContent("")
             });
         
-        var options = Options.Create(new HoneybadgerOptions("test")
+        var options = Options.Create(new HoneybadgerOptions
         {
+            ApiKey = "test",
             HttpClient = new HttpClient(mockHttpHandler.Object)
         });
         var client = new HoneybadgerClient(options);

--- a/tests/Honeybadger.Tests/NoticeFactoryTest.cs
+++ b/tests/Honeybadger.Tests/NoticeFactoryTest.cs
@@ -39,7 +39,11 @@ public class NoticeFactoryTest
     [Fact]
     public void CreatesNotice_WithBreadcrumbs()
     {
-        var client = new HoneybadgerClient(Options.Create(new HoneybadgerOptions("api_key") { ReportData = true }));
+        var client = new HoneybadgerClient(Options.Create(new HoneybadgerOptions
+        {
+            ApiKey = "test",
+            ReportData = true
+        }));
         client.AddBreadcrumb("a breadcrumb", "a category");
         var exception = new NamedException("exception");
         var notice = NoticeFactory.Make(client, exception);
@@ -60,7 +64,11 @@ public class NoticeFactoryTest
     [Fact]
     public void CreatesNotice_WithMaxBreadcrumbs()
     {
-        var options = new HoneybadgerOptions("api_key") { ReportData = true };
+        var options = new HoneybadgerOptions
+        {
+            ApiKey = "test",
+            ReportData = true
+        };
         var client = new HoneybadgerClient(Options.Create(options));
         for (var i = 0; i < options.MaxBreadcrumbs + 2; i++)
         {


### PR DESCRIPTION
Improves configuration by following best practices on custom loggers and handles cases where loggers report unhandled exceptions (ignore if `ReportUnhandledExceptions` is `false`).