### PR TITLE
feat: set backtrace frame context

### DIFF
--- a/src/Honeybadger/NoticeHelpers/ErrorFactory.cs
+++ b/src/Honeybadger/NoticeHelpers/ErrorFactory.cs
@@ -7,7 +7,7 @@ public static class ErrorFactory
 {
     public static Error Get(StackTrace stackTrace, string message, string? className = null)
     {
-        var @class = className ?? stackTrace.GetFrame(0)?.GetMethod()?.DeclaringType?.FullName ?? "CLASS"; 
+        var @class = className ?? stackTrace.GetFrame(0)?.GetMethod()?.DeclaringType?.FullName ?? "CLASS";
         return new Error(@class, message, GetBacktraces(stackTrace))
         {
             Fingerprint = null, // todo
@@ -33,10 +33,22 @@ public static class ErrorFactory
                 File = sf.GetFileName(),
                 Number = sf.GetFileLineNumber().ToString(),
                 Method = sf.GetMethod()?.Name,
-                Context = null, // todo
+                Context = DetermineContext(sf.GetFileName(), HoneybadgerClient.Current?.Options?.ProjectRoot),
             });
         }
 
         return result.ToArray();
+    }
+
+    private static string DetermineContext(string? fileName, string? projectRoot)
+    {
+        if (!string.IsNullOrEmpty(projectRoot) &&
+            !string.IsNullOrEmpty(fileName) &&
+            fileName.StartsWith(projectRoot))
+        {
+            return "app";
+        }
+
+        return "all";
     }
 }


### PR DESCRIPTION
This uses the `ProjectRoot` option to set the context for the backtrace frames, which allows us to show just the application trace.

I put this together while testing the library, but my knowledge of .NET/C# is too limited to know if this will work reliably in production apps, and it needs tests. But it seems to work locally in the example app:

![CleanShot 2025-05-14 at 09 50 30@2x](https://github.com/user-attachments/assets/b6f6c62b-a271-4b6e-a7eb-1e1778ae733c)

![CleanShot 2025-05-14 at 09 55 05@2x](https://github.com/user-attachments/assets/0d48f136-744a-48e6-96fa-ba425775d37a)

Sometimes we run into issues with compiled languages (I'm not sure what production stack frames look like), so this definitely needs some more manual testing to validate the approach.

Can you take a look when you get the chance, @subzero10?

Here's what we need if we move forward with this:

- [ ] Verify approach and that it's working
- [ ] Add tests
- [ ] Add documentation