### PR TITLE
feat: use AsyncLocal for context and breadcrumbs

### DIFF
--- a/tests/Honeybadger.Tests/HoneybadgerClientTest.cs
+++ b/tests/Honeybadger.Tests/HoneybadgerClientTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -29,7 +30,7 @@ public class HoneybadgerClientTest
     }
     
     [Fact]
-    public void SendsNotice_WithBreadcrumbs()
+    public async Task SendsNotice_WithBreadcrumbs()
     {
         const string noticeMessage = "notice with breadcrumbs";
         const string breadcrumbMessage = "breadcrumb";
@@ -38,6 +39,7 @@ public class HoneybadgerClientTest
         {
             {"metadata", "value"}
         };
+        var noticeReceived = new TaskCompletionSource();
         var mockHttpHandler = new Mock<HttpMessageHandler>();
         mockHttpHandler.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -53,9 +55,10 @@ public class HoneybadgerClientTest
                 var firstTrail = notice.Breadcrumbs.Trail[0];
                 Assert.Equal(breadcrumbMessage, firstTrail.Message);
                 Assert.Equal(breadcrumbCategory, firstTrail.Category);
-                Assert.Equal(breadcrumbMetadata, firstTrail.Metadata);
-                
-                
+                Assert.Equal(breadcrumbMetadata.Count, firstTrail.Metadata?.Count);
+                Assert.Equal(breadcrumbMetadata.First().Key, firstTrail.Metadata?.First().Key);
+                Assert.Equal(breadcrumbMetadata.First().Value, firstTrail.Metadata?.First().Value?.ToString());
+                noticeReceived.SetResult();
             })
             .ReturnsAsync(new HttpResponseMessage {
                 StatusCode = HttpStatusCode.OK,
@@ -65,21 +68,24 @@ public class HoneybadgerClientTest
         var options = Options.Create(new HoneybadgerOptions
         {
             ApiKey = "test",
-            HttpClient = new HttpClient(mockHttpHandler.Object)
+            HttpClient = new HttpClient(mockHttpHandler.Object) { BaseAddress = new Uri("https://notavaliddomain.com") }
         });
         var client = new HoneybadgerClient(options);
         client.AddBreadcrumb(breadcrumbMessage, breadcrumbCategory, breadcrumbMetadata);
+        // ReSharper disable once MethodHasAsyncOverload
         client.Notify(noticeMessage);
+        await noticeReceived.Task;
     }
     
     [Fact]
-    public void SendsNotice_WithContext()
+    public async Task SendsNotice_WithContext()
     {
         const string noticeMessage = "notice with context";
         var noticeContext = new Dictionary<string, object>()
         {
             {"user_id", 123}
         };
+        var noticeReceived = new TaskCompletionSource();
         var mockHttpHandler = new Mock<HttpMessageHandler>();
         mockHttpHandler.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -90,7 +96,10 @@ public class HoneybadgerClientTest
                 Assert.NotNull(notice);
                 Assert.Equal(noticeMessage, notice.Error.Message);
                 Assert.NotNull(notice.Request);
-                Assert.Equal(noticeContext, notice.Request.Context);
+                Assert.Equal(noticeContext.Count, notice.Request.Context?.Count);
+                Assert.Equal(noticeContext.First().Key, notice.Request.Context?.First().Key);
+                Assert.Equal(noticeContext.First().Value.ToString(), notice.Request.Context?.First().Value.ToString());
+                noticeReceived.SetResult();
             })
             .ReturnsAsync(new HttpResponseMessage {
                 StatusCode = HttpStatusCode.OK,
@@ -100,18 +109,21 @@ public class HoneybadgerClientTest
         var options = Options.Create(new HoneybadgerOptions
         {
             ApiKey = "test",
-            HttpClient = new HttpClient(mockHttpHandler.Object)
+            HttpClient = new HttpClient(mockHttpHandler.Object) { BaseAddress = new Uri("https://notavaliddomain.com") }
         });
         var client = new HoneybadgerClient(options);
         client.AddContext(noticeContext);
+        // ReSharper disable once MethodHasAsyncOverload
         client.Notify(noticeMessage);
+        await noticeReceived.Task;
     }
 
     [Fact]
-    public void SendsNotice_WithTags()
+    public async Task SendsNotice_WithTags()
     {
         const string noticeMessage = "notice with tags";
         string[] tags = ["v1.0.0"];
+        var noticeReceived = new TaskCompletionSource();
         var mockHttpHandler = new Mock<HttpMessageHandler>();
         mockHttpHandler.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -123,6 +135,7 @@ public class HoneybadgerClientTest
                 Assert.Equal(noticeMessage, notice.Error.Message);
                 Assert.NotNull(notice.Request);
                 Assert.Equal(tags, notice.Error.Tags);
+                noticeReceived.SetResult();
             })
             .ReturnsAsync(new HttpResponseMessage {
                 StatusCode = HttpStatusCode.OK,
@@ -132,17 +145,20 @@ public class HoneybadgerClientTest
         var options = Options.Create(new HoneybadgerOptions
         {
             ApiKey = "test",
-            HttpClient = new HttpClient(mockHttpHandler.Object)
+            HttpClient = new HttpClient(mockHttpHandler.Object) { BaseAddress = new Uri("https://notavaliddomain.com") }
         });
         var client = new HoneybadgerClient(options);
+        // ReSharper disable once MethodHasAsyncOverload
         client.Notify(noticeMessage, new Dictionary<string, object> { {"tags", tags } });
+        await noticeReceived.Task;
     }
     
     [Fact]
-    public void SendsNotice_WithFingerprint()
+    public async Task SendsNotice_WithFingerprint()
     {
         const string noticeMessage = "notice with tags";
         var fingerprint = Guid.NewGuid().ToString();
+        var noticeReceived = new TaskCompletionSource();
         var mockHttpHandler = new Mock<HttpMessageHandler>();
         mockHttpHandler.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -154,6 +170,7 @@ public class HoneybadgerClientTest
                 Assert.Equal(noticeMessage, notice.Error.Message);
                 Assert.NotNull(notice.Request);
                 Assert.Equal(fingerprint, notice.Error.Fingerprint);
+                noticeReceived.TrySetResult();
             })
             .ReturnsAsync(new HttpResponseMessage {
                 StatusCode = HttpStatusCode.OK,
@@ -163,10 +180,54 @@ public class HoneybadgerClientTest
         var options = Options.Create(new HoneybadgerOptions
         {
             ApiKey = "test",
-            HttpClient = new HttpClient(mockHttpHandler.Object)
+            HttpClient = new HttpClient(mockHttpHandler.Object) { BaseAddress = new Uri("https://notavaliddomain.com") }
         });
         var client = new HoneybadgerClient(options);
+        // ReSharper disable once MethodHasAsyncOverload
         client.Notify(noticeMessage, new Dictionary<string, object> { {"fingerprint", fingerprint } });
+        await noticeReceived.Task;
+    }
+
+    [Fact]
+    public async Task SendsNotice_WithBreadcrumbsPreservedAcrossAwait()
+    {
+        const string noticeMessage = "error after async work";
+        const string breadcrumbBefore = "Before await";
+        const string breadcrumbAfter = "After await";
+        var noticeReceived = new TaskCompletionSource<Notice>();
+        var mockHttpHandler = new Mock<HttpMessageHandler>();
+        mockHttpHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback((HttpRequestMessage request, CancellationToken token) =>
+            {
+                var content = request.Content?.ReadAsStringAsync(token).Result;
+                var notice = JsonSerializer.Deserialize<Notice>(content!)!;
+                noticeReceived.TrySetResult(notice);
+            })
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("")
+            });
+
+        var options = Options.Create(new HoneybadgerOptions
+        {
+            ApiKey = "test",
+            HttpClient = new HttpClient(mockHttpHandler.Object) { BaseAddress = new Uri("https://notavaliddomain.com") }
+        });
+        var client = new HoneybadgerClient(options);
+
+        client.AddBreadcrumb(breadcrumbBefore, "test");
+        await Task.Yield();
+        client.AddBreadcrumb(breadcrumbAfter, "test");
+        await client.NotifyAsync(noticeMessage);
+
+        var notice = await noticeReceived.Task;
+        Assert.NotNull(notice.Breadcrumbs);
+        Assert.True(notice.Breadcrumbs.Enabled);
+        Assert.Equal(2, notice.Breadcrumbs.Trail.Length);
+        Assert.Equal(breadcrumbBefore, notice.Breadcrumbs.Trail[0].Message);
+        Assert.Equal(breadcrumbAfter, notice.Breadcrumbs.Trail[1].Message);
     }
 
 }

--- a/tests/Honeybadger.Tests/HoneybadgerClientTest.cs
+++ b/tests/Honeybadger.Tests/HoneybadgerClientTest.cs
@@ -170,7 +170,7 @@ public class HoneybadgerClientTest
                 Assert.Equal(noticeMessage, notice.Error.Message);
                 Assert.NotNull(notice.Request);
                 Assert.Equal(fingerprint, notice.Error.Fingerprint);
-                noticeReceived.TrySetResult();
+                noticeReceived.SetResult();
             })
             .ReturnsAsync(new HttpResponseMessage {
                 StatusCode = HttpStatusCode.OK,
@@ -202,7 +202,7 @@ public class HoneybadgerClientTest
             {
                 var content = request.Content?.ReadAsStringAsync(token).Result;
                 var notice = JsonSerializer.Deserialize<Notice>(content!)!;
-                noticeReceived.TrySetResult(notice);
+                noticeReceived.SetResult(notice);
             })
             .ReturnsAsync(new HttpResponseMessage
             {


### PR DESCRIPTION
## Summary

Context and breadcrumbs in `HoneybadgerClient` now use `AsyncLocal<T>` instead of `ThreadLocal<T>`, so they are preserved correctly across `await` boundaries in async code. Previously, after an `await`, execution could resume on a different thread and the thread-local context/breadcrumbs were lost.

## Changes

- **HoneybadgerClient.cs**
  - Replaced `ThreadLocal<Dictionary<string, object>>` and `ThreadLocal<List<Trail>>` with `AsyncLocal<>` for `_context` and `_breadcrumbs`.
  - Removed `IDisposable` and `Dispose()` (no longer needed; `AsyncLocal` does not require disposal).
  - `AddContext`: now initializes context when null instead of no-op so context is always writable.
  - `AddBreadcrumb` / `GetContext`: use `??=` for lazy initialization of storage.
- **HoneybadgerClientTest.cs**
  - Tests that use fire-and-forget `Notify()` now await the HTTP callback via `TaskCompletionSource` and `await noticeReceived.Task` so assertions run after the notice is sent.
  - Set `BaseAddress` on mock `HttpClient` where required.
  - Adjusted breadcrumb metadata assertion to compare by key/value (compatible with JSON round-trip).
  - Added **SendsNotice_WithBreadcrumbsPreservedAcrossAwait**: adds a breadcrumb, `await Task.Yield()`, adds another breadcrumb, then notifies; asserts both breadcrumbs appear in the notice.

## Motivation

In async flows (e.g. ASP.NET Core request pipelines), context and breadcrumbs added before an `await` were lost after the await when execution continued on another thread. Using `AsyncLocal` keeps the logical async context and ensures breadcrumbs and custom context are included in notices.

## Breaking changes

- **API**: `HoneybadgerClient` no longer implements `IDisposable`. Callers that called `Dispose()` (e.g. in `using` or manual cleanup) should remove that; the client no longer needs disposal.